### PR TITLE
changes the task required argument from module to action

### DIFF
--- a/network_runner/resources/__init__.py
+++ b/network_runner/resources/__init__.py
@@ -62,7 +62,15 @@ class Entity(with_metaclass(EntityMeta)):
             try:
                 attr_value = kwargs[key]
             except KeyError:
-                attr_value = value.default
+                if not value.default:
+                    if value.attrtype == 'dict':
+                        attr_value = {}
+                    elif value.attrtype == 'list':
+                        attr_value = []
+                    else:
+                        attr_value = None
+                else:
+                    attr_value = value.default
 
             if value.cls and not isinstance(attr_value, type(value.cls)):
                 if not isinstance(attr_value, (list, dict)):

--- a/network_runner/resources/ansible/playbook.py
+++ b/network_runner/resources/ansible/playbook.py
@@ -25,7 +25,7 @@ from network_runner.resources.attributes import Attribute
 class Task(Entity):
 
     _name = Attribute(serialize='present')
-    _module = Attribute(required=True)
+    _action = Attribute(required=True)
     _args = Attribute(type='dict')
     _vars = Attribute(type='dict')
     _when = Attribute(serialize='present')
@@ -33,7 +33,7 @@ class Task(Entity):
 
     def serialize(self):
         obj = super(Task, self).serialize()
-        mod = obj.pop('module')
+        mod = obj.pop('action')
         args = obj.pop('args', {})
         assert isinstance(args, dict)
         obj[mod] = args
@@ -49,7 +49,7 @@ class Task(Entity):
         assert len(ds) == 1, "unknown key/value in task"
 
         for key, value in iteritems(ds):
-            obj['module'] = key
+            obj['action'] = key
             obj['args'] = value
 
         super(Task, self).deserialize(obj)

--- a/network_runner/resources/attributes.py
+++ b/network_runner/resources/attributes.py
@@ -38,12 +38,6 @@ class Attribute(object):
         if validator and self.attrtype not in validator.__required_types__:
             raise AttributeError('invalid validator for attr type')
 
-        if not self.default:
-            if self.attrtype == 'list':
-                self.default = []
-            elif self.attrtype == 'dict':
-                self.default = {}
-
         if self.attrtype == 'int':
             self._attr_type = int
         elif self.attrtype == 'bool':


### PR DESCRIPTION
This commit changes the task argument `module` to `action` to better
align with the Task() structure.

This change fixes a bug where the previous task args would be carried
over to a new task in the current play.  When the new task is created,
it should not have any args by default.