### PR TITLE
make api inventory object configurable at runtime

### DIFF
--- a/network_runner/api.py
+++ b/network_runner/api.py
@@ -19,10 +19,13 @@
 import ansible_runner
 
 from network_runner import exceptions
+
 from network_runner.resources.ansible.playbook import Playbook
 from network_runner.resources.ansible.playbook import Play
 from network_runner.resources.ansible.playbook import Task
+
 from network_runner.resources.inventory import Inventory
+from network_runner.resources.inventory.hosts import Host
 
 IMPORT_ROLE = 'import_role'
 NETWORK_RUNNER = 'network-runner'
@@ -34,9 +37,24 @@ class NetworkRunner(object):
     roles in Ansible Networking to manipulate switch configuration
     """
 
-    def __init__(self, inventory):
-        assert isinstance(inventory, Inventory)
-        self.inventory = inventory
+    def __init__(self, inventory=None):
+        if inventory is not None:
+            assert isinstance(inventory, Inventory)
+        self.inventory = inventory or Inventory()
+
+    def add_host(self, host):
+        """Add host to inventory
+
+        Adds a new ```Host``` instance to the current inventory
+        object.  The value must be a value ```Host``` instance.
+
+        :param host: A valid instance of ```Host```
+        :type host: network_runner.resources.inventory.hosts.Host
+
+        :returns: None
+        """
+        assert isinstance(host, Host)
+        self.inventory.hosts.add(host)
 
     def run(self, playbook):
         assert isinstance(playbook, Playbook)

--- a/network_runner/tests/unit/test_api.py
+++ b/network_runner/tests/unit/test_api.py
@@ -17,7 +17,25 @@ import mock
 
 from network_runner import exceptions
 from network_runner.resources.ansible import playbook
+from network_runner.resources.inventory.hosts import Host
+from network_runner.api import NetworkRunner
 from network_runner.tests.unit import base
+
+
+class TestAddHost(base.BaseTestCase):
+
+    def test_add_host(self):
+        host = Host(name='test')
+        api = NetworkRunner()
+        assert 'test' not in api.inventory.hosts
+        api.add_host(host)
+        assert 'test' in api.inventory.hosts
+
+    def test_add_host_fail(self):
+        api = NetworkRunner()
+        assert 'test' not in api.inventory.hosts
+        with self.assertRaises(AssertionError):
+            api.add_host(None)
 
 
 class TestCreateDeleteVlan(base.NetworkRunnerTestCase):


### PR DESCRIPTION
This commit allows NetworkRunner instance to be created without passing
a valid inventory (inventory=None).  It then adds a new method
add_host() that takes a single argument.  The argument is an instance
of Host which is then added to the api inventory instance.

Signed-off-by: Peter Sprygada <spsprygad@redhat.com>