### PR TITLE
updates arista eos port configuration playbooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,5 +50,5 @@ The following matrix indicates which features have been implmented.
 +--------------------+-------------+-------+------+-----+---------+----------+
 | Config Access Port |      Y      |   Y   |  Y   |  Y  |    Y    |    Y     |
 +--------------------+-------------+-------+------+-----+---------+----------+
-| Config Trunk Port  |      N      |   Y   |  N   |  N  |    N    |    N     |
+| Config Trunk Port  |      N      |   Y   |  N   |  Y  |    N    |    N     |
 +--------------------+-------------+-------+------+-----+---------+----------+

--- a/etc/ansible/roles/network-runner/providers/eos/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/eos/conf_access_port.yaml
@@ -1,63 +1,21 @@
 ---
-- name: "eos: get current status of the port"
+- name: "eos: get interfaces"
   eos_command:
-    commands:
-      - "show interface {{ port_name }} switchport | json"
-      - "show interface {{ port_name }} | json"
-      - "show running-config"
+    commands: "show interfaces | json"
   register: output
   connection: network_cli
   become: true
   become_method: 'enable'
 
-- name: "eos: set port facts"
-  set_fact:
-    switchport: "{{ output.stdout[0].switchports[port_name] }}"
-    interface: "{{ output.stdout[1].interfaces[port_name] }}"
+- name: "eos: verify port exists"
+  fail:
+    msg: "port {{ port_name }} does not exist on this device"
+  when: port_name not in output.stdout[0].interfaces | list
 
-- name: "eos: port is configured as routed"
-  block:
-    - name: "eos: reset interface to defaults"
-      eos_config:
-        lines: "default interface {{ port_name }}"
-
-    - name: "eos: build port configuration"
-      eos_config:
-        lines:
-          - "interface {{ port_name }}"
-          - "description {{ port_description }}"
-          - "switchport access vlan {{ _vlan_id }}"
-          - "no shutdown"
-        parents:
-          - "interface {{ port_name }}"
-        running_config: "{{ output.stdout[2] }}"
-  when: not switchport.enabled
+- name: "eos: configure access port"
+  cli_config:
+    config: "{{ lookup('template', '{{ role_path }}/templates/eos/conf_access_port.j2') }}"
+  register: result
   connection: network_cli
   become: true
-  become_method: 'enable'
-
-- name: "eos: port is configured as switchport"
-  block:
-    - name: "eos: set the switchport mode to access"
-      eos_config:
-        lines: "switchport mode access"
-        parents: ["interface {{ port_name }}"]
-      when: switchport.switchportInfo.mode != 'access'
-
-    - name: "eos: configure port settings"
-      eos_config:
-        lines:
-          - "description {{ port_description }}"
-          - "switchport access vlan {{ _vlan_id }}"
-        parents: ["interface {{ port_name }}"]
-        running_config: "{{ output.stdout[2] }}"
-
-    - name: "eos: administratively enable the port"
-      eos_config:
-        lines: "no shutdown"
-        parents: ["interface {{ port_name }}"]
-      when: interface.interfaceStatus == 'disabled'
-  when: switchport.enabled
-  connection: network_cli
-  become: true
-  become_method: 'enable'
+  become_method: enable

--- a/etc/ansible/roles/network-runner/providers/eos/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/eos/conf_trunk_port.yaml
@@ -1,3 +1,21 @@
 ---
-- fail:
-    msg: Trunk port configuration is not implimented for eos
+- name: "eos: get interfaces"
+  eos_command:
+    commands: "show interfaces | json"
+  register: output
+  connection: network_cli
+  become: true
+  become_method: 'enable'
+
+- name: "eos: verify port exists"
+  fail:
+    msg: "port {{ port_name }} does not exist on this device"
+  when: port_name not in output.stdout[0].interfaces | list
+
+- name: "eos: configure trunk port"
+  cli_config:
+    config: "{{ lookup('template', '{{ role_path }}/templates/eos/conf_trunk_port.j2') }}"
+  register: result
+  connection: network_cli
+  become: true
+  become_method: enable

--- a/etc/ansible/roles/network-runner/providers/eos/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/eos/delete_port.yaml
@@ -12,17 +12,10 @@
     msg: "port {{ port_name }} does not exist on this device"
   when: port_name not in output.stdout[0].interfaces | list
 
-- name: "eos: remove port configuration"
-  eos_config:
-    lines: "default interface {{ port_name }}"
+- name: "eos: delete the port configuration"
+  cli_config:
+    config: "{{ lookup('template', '{{ role_path }}/templates/eos/delete_port.j2') }}"
+  register: result
   connection: network_cli
   become: true
-  become_method: 'enable'
-
-- name: "eos: administratively disable the port"
-  eos_config:
-    lines: "shutdown"
-    parents: ["interface {{ port_name }}"]
-  connection: network_cli
-  become: true
-  become_method: 'enable'
+  become_method: enable

--- a/etc/ansible/roles/network-runner/templates/eos/conf_access_port.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/conf_access_port.j2
@@ -1,0 +1,9 @@
+default interface {{ port_name }}
+interface {{ port_name }}
+{% if port_description %}
+description {{ port_description }}
+{% endif %}
+switchport
+switchport mode access
+switchport access vlan {{ vlan_id }}
+no shutdown

--- a/etc/ansible/roles/network-runner/templates/eos/conf_trunk_port.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/conf_trunk_port.j2
@@ -1,0 +1,12 @@
+default interface {{ port_name }}
+interface {{ port_name }}
+{% if port_description %}
+description {{ port_description }}
+{% endif %}
+switchport
+switchport mode trunk
+{% if vlan_id %}
+switchport trunk native vlan {{ vlan_id }}
+{% endif %}
+switchport trunk allowed vlan {{ trunked_vlans | join(",") }}
+no shutdown

--- a/etc/ansible/roles/network-runner/templates/eos/delete_port.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/delete_port.j2
@@ -1,0 +1,3 @@
+default interface {{ port_name }}
+interface {{ port_name }}
+shutdown

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -4,7 +4,7 @@ import json
 from network_runner import api
 from network_runner.resources.inventory import Inventory
 
-TRUNK_SUPPORT = ('junos', 'openvswitch')
+TRUNK_SUPPORT = ('junos', 'openvswitch', 'eos')
 PORTS = {
     'eos': 'Ethernet1',
     'junos': 'xe-0/0/1',


### PR DESCRIPTION
This commit updates the arista eos provider to pull configuration from
templates instead of directly from the task list.  It also adds support
for ```conf_trunk_port``` to arista eos devices.

Signed-off-by: Peter Sprygada <psprygad@redhat.com>