### PR TITLE
refactor eos vlan functions to use templates

### DIFF
--- a/etc/ansible/roles/network-runner/providers/eos/create_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/eos/create_vlan.yaml
@@ -1,10 +1,8 @@
 ---
 - name: "eos: create vlan using network_cli"
-  eos_config:
-    lines:
-      - "name {{ _vlan_name }}"
-    parents:
-      - "vlan {{ _vlan_id }}"
+  cli_config:
+    config: "{{ lookup('template', '{{ role_path }}/templates/eos/create_vlan.j2') }}"
+  register: result
   connection: network_cli
   become: true
-  become_method: 'enable'
+  become_method: enable

--- a/etc/ansible/roles/network-runner/providers/eos/delete_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/eos/delete_vlan.yaml
@@ -1,7 +1,8 @@
 ---
 - name: "eos: delete vlan using network_cli"
-  eos_config:
-    lines: "no vlan {{ _vlan_id }}"
+  cli_config:
+    config: "{{ lookup('template', '{{ role_path }}/templates/eos/delete_vlan.j2') }}"
+  register: result
   connection: network_cli
   become: true
-  become_method: 'enable'
+  become_method: enable

--- a/etc/ansible/roles/network-runner/templates/eos/create_vlan.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/create_vlan.j2
@@ -1,0 +1,2 @@
+vlan {{ _vlan_id }}
+name {{ _vlan_name }}

--- a/etc/ansible/roles/network-runner/templates/eos/delete_vlan.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/delete_vlan.j2
@@ -1,0 +1,1 @@
+no vlan {{ _vlan_id }}


### PR DESCRIPTION
This commit changes the create_vlan and delete_vlan includes to
implement templates instead of encoding configuration in the task list.

Signed-off-by: Peter Sprygada <psprygad@redhat.com>