### PR TITLE
updates functional tests to use local inventory file

### DIFF
--- a/tests/functional.py
+++ b/tests/functional.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 
 from network_runner import api
 from network_runner.resources.inventory import Inventory
@@ -16,12 +17,13 @@ HOSTNAME = 'eos-4.20.10'
 HOSTNAME = 'appliance'
 VLAN = 37
 T_VLANS = [3, 7, 73]
+INVENTORY_FILE = os.getenv('ANSIBLE_INVENTORY_FILE', '/etc/ansible/hosts')
 
 
 def get_parser_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--hosts', help='hosts file',
-                        default='/etc/ansible/hosts')
+                        default=INVENTORY_FILE)
     return parser.parse_args()
 
 
@@ -48,6 +50,7 @@ def get_inv_yaml(args):
 
 def run_tests(inventory, hostname, port, trunk=False):
     # TODO(radez) Use a testing framework to verify
+
 
     net_runr = api.NetworkRunner(inventory)
     # ## Create a vlan

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -51,7 +51,6 @@ def get_inv_yaml(args):
 def run_tests(inventory, hostname, port, trunk=False):
     # TODO(radez) Use a testing framework to verify
 
-
     net_runr = api.NetworkRunner(inventory)
     # ## Create a vlan
     net_runr.create_vlan(hostname, VLAN)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.4.2
+minversion = 3.4.0
 envlist = py36,py37,py27,func,linters
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ setenv =
    OS_STDOUT_CAPTURE=1
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
+    ANSIBLE_ROLES_PATH={toxworkdir}/../etc/ansible/roles
+    ANSIBLE_INVENTORY_FILE={env:ANSIBLE_INVENTORY_FILE:/etc/ansible/hosts}
 deps = -r{toxinidir}/test-requirements.txt
-#commands = python -m unittest discover network_runner/tests/unit --pattern=*.py
 commands = pytest --cov=network_runner tests/ -v
 
 [testenv:func]

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ setenv =
    OS_STDOUT_CAPTURE=1
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
-    ANSIBLE_ROLES_PATH={toxworkdir}/../etc/ansible/roles
-    ANSIBLE_INVENTORY_FILE={env:ANSIBLE_INVENTORY_FILE:/etc/ansible/hosts}
+   ANSIBLE_ROLES_PATH={toxworkdir}/../etc/ansible/roles
+   ANSIBLE_INVENTORY_FILE={env:ANSIBLE_INVENTORY_FILE:/etc/ansible/hosts}
 deps = -r{toxinidir}/test-requirements.txt
 commands = pytest --cov=network_runner tests/ -v
 


### PR DESCRIPTION
This commit updates the functional tests (`tox -e func`) to allow for a
developer local inventory file.  In order to provide a custom inventory
file, simply set the env variable `ANSIBLE_INVENTORY_FILE` to the path of
the inventory file to use.  Then run `tox -e func` and the functional
tests will connect to local development instances.

Depends-On: https://github.com/ansible-network/network-runner/pull/33
Signed-off-by: Peter Sprygada <psprygad@redhat.com>