### PR TITLE
Always upgrade to latest tox for testing

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
+# to the latest version
+# NOTE(pabelanger): Cap zipp<0.6.0 due to python2.7 issue with more-iterrtools
+# https://github.com/jaraco/zipp/issues/14
+sudo pip install -U tox "zipp<0.6.0"


### PR DESCRIPTION
This gives us a much newer version then the distro tox shipped, which is
required for newer functions.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>