### PR TITLE
Prepare for centos-8 testing

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# NOTE(pabelanger): Default to pip3, when possible this is becaue python2
+# support is EOL.
+PIP=$(command -v pip3) || PIP=$(command -v pip2)
+
 # NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
 # to the latest version
 # NOTE(pabelanger): Cap zipp<0.6.0 due to python2.7 issue with more-iterrtools
 # https://github.com/jaraco/zipp/issues/14
-sudo pip install -U tox "zipp<0.6.0"
+sudo $PIP install -U tox "zipp<0.6.0"


### PR DESCRIPTION
With python2 EOL around the corner, and need to use centos-8 for
testing, update tox using pip3 when possible. If we cannot find it,
fallback to pip2.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>