### PR TITLE
configure trunk port on cisco switches running nxos

### DIFF
--- a/etc/ansible/roles/network-runner/providers/nxos/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nxos/conf_trunk_port.yaml
@@ -1,3 +1,82 @@
 ---
-- fail:
-    msg: Trunk port configuration is not implimented for nxos
+- name: "nxos: get current status of the port"
+  nxos_command:
+    commands:
+      - "show interface {{ port_name }} switchport | json"
+      - "show interface {{ port_name }} | json"
+      - "show running-config"
+  register: output
+  connection: network_cli
+
+- name: "nxos: set port facts"
+  set_fact:
+    switchport: "{{ output.stdout[0].TABLE_interface.ROW_interface }}"
+    interface: "{{ output.stdout[1].TABLE_interface.ROW_interface }}"
+
+- name: "nxos: Parse switch output to get list of trunk vlans"
+  vars:
+    all_trunk_vlans: []
+  block:
+    - name: "iterate over ranges"
+      set_fact:
+        all_trunk_vlans: "{{ all_trunk_vlans }}"
+      when: t_vlan_range.find("-") != -1
+      with_items: "{{ switchport.trunk_vlans.split(',') }}"
+      loop_control:
+        loop_var: t_vlan_range
+
+    - name: "add single vlans"
+      set_fact:
+        all_trunk_vlans: "{{ all_trunk_vlans }} + ['{{ t_vlan }}']"
+      when: t_vlan.find("-") == -1
+      with_items: "{{ switchport.trunk_vlans.split(',') }}"
+      loop_control:
+        loop_var: t_vlan
+
+    - name: "all the trunk vlans"
+      debug:
+        var: all_trunk_vlans
+
+- name: "nxos: Configure trunk port"
+  block:
+    - name: "nxos: reset interface to defaults"
+      nxos_config:
+        lines: "default interface {{ port_name }}"
+      when: switchport.switchport == 'Disabled' or switchport.oper_mode != 'trunk'
+
+    - name: "nxos: Set switchport oper_mode to trunk"
+      nxos_config:
+        lines:
+          - "switchport"
+          - "switchport mode trunk"
+          - "switchport trunk allowed vlan none"
+          - "description {{ port_description }}"
+        parents: ["interface {{ port_name }}"]
+        running_config: "{{ output.stdout[2] }}"
+      when: switchport.oper_mode != 'trunk'
+
+    - name: "nxos: administratively enable the port"
+      nxos_config:
+        lines: "no shutdown"
+        parents: ["interface {{ port_name }}"]
+      when: interface.admin_state == 'down'
+
+    - name: "nxos: add trunk vlan"
+      nxos_config:
+        lines:
+          - "switchport trunk allowed vlan add {{t_vlan}}"
+        parents: ["interface {{ port_name }}"]
+        running_config: "{{ output.stdout[2] }}"
+      with_items: "{% for vlan in trunked_vlans %} {{ vlan }}{% endfor %}"
+      loop_control:
+        loop_var: t_vlan
+
+    - name: "nxos: set native vlan"
+      nxos_config:
+        lines:
+          - "switchport trunk native vlan {{ _vlan_id }}"
+        parents: ["interface {{ port_name }}"]
+        running_config: "{{ output.stdout[2] }}"
+      when: switchport.native_vlan != _vlan_id
+  connection: network_cli
+

--- a/etc/ansible/roles/network-runner/providers/nxos/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nxos/conf_trunk_port.yaml
@@ -13,29 +13,31 @@
     switchport: "{{ output.stdout[0].TABLE_interface.ROW_interface }}"
     interface: "{{ output.stdout[1].TABLE_interface.ROW_interface }}"
 
-- name: "nxos: Parse switch output to get list of trunk vlans"
+- name: "nxos: Parse switch output to get list of all active vlans"
   vars:
-    all_trunk_vlans: []
+    all_active_vlans: []
   block:
-    - name: "iterate over ranges"
+    - name: "convert ranges to list of vlans"
       set_fact:
-        all_trunk_vlans: "{{ all_trunk_vlans }}"
+        all_active_vlans: >-
+          {{ (
+          all_active_vlans
+          + range(r[0]|int, r[1]|int+1)|list
+          )|sort }}
+      vars:
+        r: "{{ t_vlan_range.split('-') }}"
       when: t_vlan_range.find("-") != -1
       with_items: "{{ switchport.trunk_vlans.split(',') }}"
       loop_control:
         loop_var: t_vlan_range
 
-    - name: "add single vlans"
+    - name: "add single vlans to the list"
       set_fact:
-        all_trunk_vlans: "{{ all_trunk_vlans }} + ['{{ t_vlan }}']"
+        all_active_vlans: "{{ (all_active_vlans + [t_vlan|int])|sort }}"
       when: t_vlan.find("-") == -1
       with_items: "{{ switchport.trunk_vlans.split(',') }}"
       loop_control:
         loop_var: t_vlan
-
-    - name: "all the trunk vlans"
-      debug:
-        var: all_trunk_vlans
 
 - name: "nxos: Configure trunk port"
   block:
@@ -67,16 +69,28 @@
           - "switchport trunk allowed vlan add {{t_vlan}}"
         parents: ["interface {{ port_name }}"]
         running_config: "{{ output.stdout[2] }}"
-      with_items: "{% for vlan in trunked_vlans %} {{ vlan }}{% endfor %}"
+      when: t_vlan|int not in all_active_vlans
+      loop: "{{ trunked_vlans }}"
       loop_control:
         loop_var: t_vlan
 
     - name: "nxos: set native vlan"
       nxos_config:
         lines:
+          - "switchport trunk allowed vlan add {{_vlan_id}}"
           - "switchport trunk native vlan {{ _vlan_id }}"
         parents: ["interface {{ port_name }}"]
         running_config: "{{ output.stdout[2] }}"
-      when: switchport.native_vlan != _vlan_id
-  connection: network_cli
+      when: switchport.native_vlan|int != _vlan_id|int or _vlan_id|int not in all_active_vlans
 
+    - name: "nxos: remove vlans that aren't required"
+      nxos_config:
+        lines:
+          - "switchport trunk allowed vlan remove {{ stale_vlan }}"
+        parents: ["interface {{ port_name }}"]
+        running_config: "{{ output.stdout[2] }}"
+      when: stale_vlan|string not in trunked_vlans+[_vlan_id] and stale_vlan != 0
+      loop: "{{ all_active_vlans }}"
+      loop_control:
+        loop_var: stale_vlan
+  connection: network_cli


### PR DESCRIPTION
We are working on deploying Openstack baremetal services (Ironic and related services) at the [Mass Open Cloud](https://massopen.cloud) to replace our own [HIL](https://github.com/cci-moc/hil) setup.  We wanted to be able to configure trunk ports on our test switch as part of that, which is why I wrote this. 

Test switch specs:
```
Software
  BIOS: version 5.1.0
 NXOS: version 9.2(3)
  BIOS compile time:  05/20/2018
  NXOS image file is: bootflash:///nxos.9.2.3.bin
  NXOS compile time:  2/17/2019 5:00:00 [02/17/2019 15:07:27]


Hardware
  cisco Nexus3500 C3548P-10G Chassis 
  Intel(R) Pentium(R) CPU  @ 1.50GHz with 4024204 kB of memory.
  Processor Board ID FOC18028M4C
```