### PR TITLE
Change junos appliance name

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -6,5 +6,5 @@
 
 - job:
     name: network-runner-test-functional-junos
-    parent: ansible-network-junos-appliance
+    parent: ansible-network-junos-vsrx-appliance
     run: tests/run.yaml


### PR DESCRIPTION
This commit changes ansible-network-junos-appliance name to
ansible-network-junos-vsrx-appliance, as per the new naming convention.