### PR TITLE
Add has host to api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*cover
 .hypothesis/
 .pytest_cache/
 

--- a/network_runner/api.py
+++ b/network_runner/api.py
@@ -40,6 +40,19 @@ class NetworkRunner(object):
             assert isinstance(inventory, Inventory)
         self.inventory = inventory or Inventory()
 
+    def has_host(self, host):
+        """Check if given host is in the inventory
+
+        :param host: Name or ansible host of ```Host```
+        :type host: String
+
+        :returns: Boolean
+        """
+        for n, h in self.inventory.hosts.items():
+            if h.ansible_host == host or n == host:
+                return True
+        return False
+
     def add_host(self, host):
         """Add host to inventory
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -23,6 +23,30 @@ from network_runner.api import NetworkRunner
 from . import base
 
 
+class TestGetHost(base.BaseTestCase):
+
+    def test_get_host(self):
+        host = Host(name='test')
+        api = NetworkRunner()
+        api.add_host(host)
+        ret = api.has_host('test')
+        self.assertTrue(ret)
+
+    def test_get_host_fail(self):
+        host = Host(name='test1')
+        api = NetworkRunner()
+        api.add_host(host)
+        ret = api.has_host('test')
+        self.assertFalse(ret)
+
+    def test_get_host_by_ansible_host(self):
+        host = Host(name='test1', ansible_host='test2')
+        api = NetworkRunner()
+        api.add_host(host)
+        ret = api.has_host('test2')
+        self.assertTrue(ret)
+
+
 class TestAddHost(base.BaseTestCase):
 
     def test_add_host(self):


### PR DESCRIPTION
It is sometimes useful to be able to query whether the runner has
a given host in its inventory, for example in order to catch
configuration mistakes.

Also cover wasn't in the gitignore for some reason