### PR TITLE
fix ovs delete port

### DIFF
--- a/etc/ansible/roles/network-runner/providers/openvswitch/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/openvswitch/delete_port.yaml
@@ -1,8 +1,7 @@
 ---
 - name: "openvswitch: delete port"
-  openvswitch_db:
-    table: Port
-    record: "{{ port_name }}"
-    col: tag
-    value: "[]"
+  openvswitch_port:
+    bridge: "{{ bridge_name }}"
+    port: "{{ port_name }}"
+    state: absent
   become: true


### PR DESCRIPTION
During delete_port operation on the ovs switch, it was found that the deletion operation could not be performed, and the operation was successful after modification.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>