### PR TITLE
Fix nxos conf_trunk_port playbook

### DIFF
--- a/etc/ansible/roles/network-runner/providers/nxos/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nxos/conf_trunk_port.yaml
@@ -12,10 +12,11 @@
   set_fact:
     switchport: "{{ output.stdout[0].TABLE_interface.ROW_interface }}"
     interface: "{{ output.stdout[1].TABLE_interface.ROW_interface }}"
+    needs_reset: "{{ output.stdout[0].TABLE_interface.ROW_interface.switchport == 'Disabled' or output.stdout[0].TABLE_interface.ROW_interface.oper_mode != 'trunk' }}"
+    all_active_vlans: []
 
 - name: "nxos: Parse switch output to get list of all active vlans"
-  vars:
-    all_active_vlans: []
+  when: not needs_reset
   block:
     - name: "convert ranges to list of vlans"
       set_fact:
@@ -44,7 +45,7 @@
     - name: "nxos: reset interface to defaults"
       nxos_config:
         lines: "default interface {{ port_name }}"
-      when: switchport.switchport == 'Disabled' or switchport.oper_mode != 'trunk'
+      when: needs_reset
 
     - name: "nxos: Set switchport oper_mode to trunk"
       nxos_config:
@@ -89,7 +90,7 @@
           - "switchport trunk allowed vlan remove {{ stale_vlan }}"
         parents: ["interface {{ port_name }}"]
         running_config: "{{ output.stdout[2] }}"
-      when: stale_vlan|string not in trunked_vlans+[_vlan_id] and stale_vlan != 0
+      when: stale_vlan|int not in trunked_vlans+[_vlan_id|int] and stale_vlan != 0
       loop: "{{ all_active_vlans }}"
       loop_control:
         loop_var: stale_vlan


### PR DESCRIPTION
When a port is deleted, a nxos switch will mark every vlan as allowed, resulting in undesirable behavior in subsequent runs of the playbook. This PR updates the playbook to check if the port is deleted and set active vlans appropriately. It also fixes some variable type casting.
