### PR TITLE
build provider list dynamically

### DIFF
--- a/network_runner/models/inventory.py
+++ b/network_runner/models/inventory.py
@@ -23,9 +23,20 @@ from network_runner.types.attrs import SERIALIZE_WHEN_NEVER
 from network_runner.types.validators import ChoiceValidator
 
 
-NETWORK_OS_VALIDATOR = ChoiceValidator(
-    choices=('cumulus', 'dellos10', 'eos', 'junos', 'nxos', 'openvswitch')
-)
+# Build the list of platform modules in the role providers directory
+import os
+RP_DEFAULT = '/usr/share/ansible/roles:/etc/ansible/roles:etc/ansible/roles'
+ROLE_PATH = os.environ.get('ANSIBLE_ROLES_PATH', RP_DEFAULT).split(':')
+PROVIDERS = []
+for i in ROLE_PATH:
+    net_runner_path = os.path.sep.join([i, 'network-runner'])
+    if os.path.exists(net_runner_path):
+        provider_path = os.path.sep.join([net_runner_path, 'providers'])
+        PROVIDERS.extend(os.listdir(provider_path))
+        break  # assume one installation of network-runner
+
+# Create a validator from the providers list
+NETWORK_OS_VALIDATOR = ChoiceValidator(choices=(PROVIDERS))
 
 
 class Host(Object):


### PR DESCRIPTION
There have been requests to make it easier to drop new providers
into the library without having to make changes to the network-runner
api code. This change looks for network-runner and lists the providers
directory as the set of providers to be validated against at run time.