### PR TITLE
build provider list for validation dynamically

### DIFF
--- a/network_runner/resources/inventory/hosts.py
+++ b/network_runner/resources/inventory/hosts.py
@@ -20,8 +20,20 @@ from network_runner.resources import Entity, KeyedCollection
 from network_runner.resources.attributes import Attribute
 from network_runner.resources.validators import ChoiceValidator
 
-net_os_validator = ChoiceValidator(choices=('cumulus', 'dellos10', 'eos',
-                                            'junos', 'nxos', 'openvswitch'))
+# Build the list of platform modules in the role providers directory
+import os
+RP_DEFAULT = '/usr/share/ansible/roles:/etc/ansible/roles:etc/ansible/roles'
+ROLE_PATH = os.environ.get('ANSIBLE_ROLES_PATH', RP_DEFAULT).split(':')
+PROVIDERS = []
+for i in ROLE_PATH:
+    net_runner_path = os.path.sep.join([i, 'network-runner'])
+    if os.path.exists(net_runner_path):
+        provider_path = os.path.sep.join([net_runner_path, 'providers'])
+        PROVIDERS.extend(os.listdir(provider_path))
+        break  # assume one installation of network-runner
+
+# Create a validator from the providers list
+net_os_validator = ChoiceValidator(choices=(PROVIDERS))
 
 
 class Host(Entity):


### PR DESCRIPTION
There have been requests to make it easier to drop new providers
into the library without having to make changes to the network-runner
api code. This change looks for network-runner and lists the providers
directory as the set of providers to be validated against at run time.

Cherry-Picked from: 0da7d871632f93ad63278651d70d7bd49e52c421