### PR TITLE
Add **kwargs to api calls

### DIFF
--- a/network_runner/api.py
+++ b/network_runner/api.py
@@ -27,8 +27,14 @@ from network_runner.resources.ansible.playbook import Task
 from network_runner.resources.inventory import Inventory
 from network_runner.resources.inventory.hosts import Host
 
+ALL = 'all'
 IMPORT_ROLE = 'import_role'
 NETWORK_RUNNER = 'network-runner'
+CREATE_VLAN = 'create_vlan'
+DELETE_VLAN = 'delete_vlan'
+CONF_ACCESS_PORT = 'conf_access_port'
+CONF_TRUNK_PORT = 'conf_trunk_port'
+DELETE_PORT = 'delete_port'
 
 
 class NetworkRunner(object):
@@ -71,7 +77,7 @@ class NetworkRunner(object):
 
         return result
 
-    def create_vlan(self, hostname, vlan_id, vlan_name=None):
+    def create_vlan(self, hostname, vlan_id, vlan_name=None, **kwargs):
         """Create VLAN.
 
         :param hostname: The name of the host in Ansible inventory.
@@ -82,11 +88,13 @@ class NetworkRunner(object):
                     hosts=hostname,
                     gather_facts=False)
 
+        variables = {'vlan_id': vlan_id}
+        variables.update(kwargs)
         task = Task(name='Create VLAN',
                     module=IMPORT_ROLE,
                     args={'name': NETWORK_RUNNER,
-                          'tasks_from': 'create_vlan'},
-                    vars={'vlan_id': vlan_id})
+                          'tasks_from': CREATE_VLAN},
+                    vars=variables)
 
         play.tasks.add(task)
 
@@ -95,7 +103,7 @@ class NetworkRunner(object):
 
         return self.run(playbook)
 
-    def delete_vlan(self, hostname, vlan_id):
+    def delete_vlan(self, hostname, vlan_id, **kwargs):
         """Delete VLAN.
 
         :param hostname: The name of the host in Ansible inventory.
@@ -105,11 +113,13 @@ class NetworkRunner(object):
                     hosts=hostname,
                     gather_facts=False)
 
+        variables = {'vlan_id': vlan_id}
+        variables.update(kwargs)
         task = Task(name='Delete VLAN',
                     module=IMPORT_ROLE,
                     args={'name': NETWORK_RUNNER,
-                          'tasks_from': 'delete_vlan'},
-                    vars={'vlan_id': vlan_id})
+                          'tasks_from': DELETE_VLAN},
+                    vars=variables)
 
         play.tasks.add(task)
 
@@ -118,7 +128,7 @@ class NetworkRunner(object):
 
         return self.run(playbook)
 
-    def conf_access_port(self, hostname, port, vlan_id):
+    def conf_access_port(self, hostname, port, vlan_id, **kwargs):
         """Configure access port on a vlan.
 
         :param hostname: The name of the host in Ansible inventory.
@@ -132,14 +142,15 @@ class NetworkRunner(object):
         play = Play(name=play_name,
                     hosts=hostname,
                     gather_facts=False)
-
+        variables = {'vlan_id': vlan_id,
+                     'port_name': port,
+                     'port_description': port}
+        variables.update(kwargs)
         task = Task(name='Configure port in access mode',
                     module=IMPORT_ROLE,
                     args={'name': NETWORK_RUNNER,
-                          'tasks_from': 'conf_access_port'},
-                    vars={'vlan_id': vlan_id,
-                          'port_name': port,
-                          'port_description': port})
+                          'tasks_from': CONF_ACCESS_PORT},
+                    vars=variables)
 
         play.tasks.add(task)
 
@@ -148,7 +159,8 @@ class NetworkRunner(object):
 
         return self.run(playbook)
 
-    def conf_trunk_port(self, hostname, port, vlan_id, trunked_vlans):
+    def conf_trunk_port(self, hostname, port, vlan_id,
+                        trunked_vlans, **kwargs):
         """Configure trunk port w/ default vlan and optional additional vlans
 
         :param hostname: The name of the host in Ansible inventory.
@@ -165,14 +177,16 @@ class NetworkRunner(object):
                     hosts=hostname,
                     gather_facts=False)
 
+        variables = {'vlan_id': vlan_id,
+                     'port_name': port,
+                     'port_description': port,
+                     'trunked_vlans': trunked_vlans}
+        variables.update(kwargs)
         task = Task(name='Configure port in trunk mode',
                     module=IMPORT_ROLE,
                     args={'name': NETWORK_RUNNER,
-                          'tasks_from': 'conf_trunk_port'},
-                    vars={'vlan_id': vlan_id,
-                          'port_name': port,
-                          'port_description': port,
-                          'trunked_vlans': trunked_vlans})
+                          'tasks_from': CONF_TRUNK_PORT},
+                    vars=variables)
 
         play.tasks.add(task)
 
@@ -181,7 +195,7 @@ class NetworkRunner(object):
 
         return self.run(playbook)
 
-    def delete_port(self, hostname, port):
+    def delete_port(self, hostname, port, **kwargs):
         """Delete port configuration.
 
         :param hostname: The name of the host in Ansible inventory.
@@ -191,11 +205,13 @@ class NetworkRunner(object):
                     hosts=hostname,
                     gather_facts=False)
 
+        variables = {'port_name': port}
+        variables.update(kwargs)
         task = Task(name='Delete port',
                     module=IMPORT_ROLE,
                     args={'name': NETWORK_RUNNER,
-                          'tasks_from': 'delete_port'},
-                    vars={'port_name': port})
+                          'tasks_from': DELETE_PORT},
+                    vars=variables)
 
         play.tasks.add(task)
 

--- a/network_runner/resources/__init__.py
+++ b/network_runner/resources/__init__.py
@@ -88,7 +88,7 @@ class Entity(with_metaclass(EntityMeta)):
         super(Entity, self).__init__()
 
     def __repr__(self):
-        return json.dumps(self.serialize())
+        return str(self.serialize())
 
     def __setattr__(self, key, value):
         if key in self._attributes:
@@ -155,7 +155,7 @@ class Collection(MutableSequence):
         self.items = list()
 
     def __repr__(self):
-        return json.dumps(self.serialize())
+        return str(self.serialize())
 
     def __getitem__(self, index):
         return self.__dict__['items'][index]
@@ -221,7 +221,7 @@ class KeyedCollection(MutableMapping):
         self.objects = {}
 
     def __repr__(self):
-        return json.dumps(self.serialize())
+        return str(self.serialize())
 
     def __getitem__(self, key):
         return self.__dict__['objects'][key]

--- a/network_runner/tests/unit/test_api.py
+++ b/network_runner/tests/unit/test_api.py
@@ -50,6 +50,20 @@ class TestCreateDeleteVlan(base.NetworkRunnerTestCase):
         self.net_runr.delete_vlan(self.testhost, self.testvlan)
         m_run_task.assert_called_once()
 
+    @mock.patch('network_runner.api.NetworkRunner.run')
+    def test_create_vlan_w_kwarg(self, m_run_task):
+        self.net_runr.create_vlan(self.testhost,
+                                  self.testvlan,
+                                  mykwarg='noval')
+        m_run_task.assert_called_once()
+
+    @mock.patch('network_runner.api.NetworkRunner.run')
+    def test_delete_vlan_w_kwarg(self, m_run_task):
+        self.net_runr.delete_vlan(self.testhost,
+                                  self.testvlan,
+                                  mykwarg='noval')
+        m_run_task.assert_called_once()
+
 
 @mock.patch('network_runner.api.ansible_runner')
 class TestRun(base.NetworkRunnerTestCase):
@@ -96,6 +110,29 @@ class TestConfAccessPort(base.NetworkRunnerTestCase):
                           self.net_runr.delete_port,
                           self.testhost, self.testport)
 
+    def test_assign_access_port_w_kwarg(self, m_run_task):
+        self.net_runr.conf_access_port(self.testhost,
+                                       self.testport,
+                                       self.testvlan,
+                                       mykwarg='no-val')
+        m_run_task.assert_called_once()
+
+        # check no-val
+        args, kwargs = m_run_task.call_args_list[0]
+        task = args[0][0].tasks[0]
+        self.assertEqual(task.vars['mykwarg'], 'no-val')
+
+    def test_remove_access_port_w_kwarg(self, m_run_task):
+        self.net_runr.delete_port(self.testhost,
+                                  self.testport,
+                                  mykwarg='no-val')
+        m_run_task.assert_called_once()
+
+        # check no-val
+        args, kwargs = m_run_task.call_args_list[0]
+        task = args[0][0].tasks[0]
+        self.assertEqual(task.vars['mykwarg'], 'no-val')
+
 
 @mock.patch('network_runner.api.NetworkRunner.run')
 class TestConfTrunkPort(base.NetworkRunnerTestCase):
@@ -118,3 +155,27 @@ class TestConfTrunkPort(base.NetworkRunnerTestCase):
         self.assertRaises(exceptions.NetworkRunnerException,
                           self.net_runr.delete_port,
                           self.testhost, self.testport)
+
+    def test_assign_trunk_port_w_kwarg(self, m_run_task):
+        self.net_runr.conf_trunk_port(self.testhost,
+                                      self.testport,
+                                      self.testvlan,
+                                      trunked_vlans=self.testvlans,
+                                      mykwarg='no-val')
+        m_run_task.assert_called_once()
+
+        # check no-val
+        args, kwargs = m_run_task.call_args_list[0]
+        task = args[0][0].tasks[0]
+        self.assertEqual(task.vars['mykwarg'], 'no-val')
+
+    def test_remove_trunk_port_w_kwarg(self, m_run_task):
+        self.net_runr.delete_port(self.testhost,
+                                  self.testport,
+                                  mykwarg='no-val')
+        m_run_task.assert_called_once()
+
+        # check no-val
+        args, kwargs = m_run_task.call_args_list[0]
+        task = args[0][0].tasks[0]
+        self.assertEqual(task.vars['mykwarg'], 'no-val')


### PR DESCRIPTION
In the case that a provider needs extra variables that are
specifict to that provider, kwargs will pass those variables
through the api to the playbooks.

This method allows providers to have custom values passed without
having to add each individual parameter added to the api for handling.

Cherry-Picked from: f3ec3fc46b3d1ae321b07a5c2e9403c910ff259d