### PR TITLE
[WIP] Remove the use of "default interface" on EOS

### DIFF
--- a/etc/ansible/roles/network-runner/templates/eos/clean_config.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/clean_config.j2
@@ -4,3 +4,4 @@ no switchport access vlan
 no switchport trunk allowed vlan
 no switchport trunk native vlan
 no description
+

--- a/etc/ansible/roles/network-runner/templates/eos/clean_config.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/clean_config.j2
@@ -1,0 +1,6 @@
+no switchport
+no switchport mode
+no switchport access vlan
+no switchport trunk allowed vlan
+no switchport trunk native vlan
+no description

--- a/etc/ansible/roles/network-runner/templates/eos/conf_access_port.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/conf_access_port.j2
@@ -1,5 +1,5 @@
-default interface {{ port_name }}
 interface {{ port_name }}
+{% include "clean_config.j2" %}
 {% if port_description %}
 description {{ port_description }}
 {% endif %}

--- a/etc/ansible/roles/network-runner/templates/eos/conf_trunk_port.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/conf_trunk_port.j2
@@ -1,5 +1,5 @@
-default interface {{ port_name }}
 interface {{ port_name }}
+{% include "clean_config.j2" %}
 {% if port_description %}
 description {{ port_description }}
 {% endif %}

--- a/etc/ansible/roles/network-runner/templates/eos/delete_port.j2
+++ b/etc/ansible/roles/network-runner/templates/eos/delete_port.j2
@@ -1,3 +1,3 @@
-default interface {{ port_name }}
 interface {{ port_name }}
+{% include "clean_config.j2" %}
 shutdown


### PR DESCRIPTION
Using "default interface" to clear configurations on each port
causes issues on EOS when the port must have a speed set in the interface
stanza due to not conforming to the switch's default breakout mode.

For example, configuring a port that is set to 40G will revert it back to 4x10G mode on a
7050QX switch. Simply adding a speed option would cause the entire switch
to stop forwarding when any port is moved from breakout to non-breakout mode,
so this patch removes the use of "default interface" in favor of explicitly clearing
relevant configurations.