### PR TITLE
Add support for dell switches running dell emc os9

### DIFF
--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/add_trunk_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/add_trunk_vlan.yaml
@@ -1,0 +1,7 @@
+---
+- name: "dellemc.os9: Add a vlan to a trunk port"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface vlan {{ _vlan_id }}"
+      - "tagged {{ port_name }}"
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -1,0 +1,23 @@
+---
+- name: "dellemc.os9: reset interface to default"
+  dellemc.os9.os9_config:
+    lines:
+      - "default interface {{ port_name }}"
+  connection: network_cli
+
+- name: "dellemc.os9: enable switchport, rstp, and jumbo frames"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface {{ port_name }}"
+      - "switchport"
+      - "no shutdown"
+      - "spanning-tree rstp edge-port"
+      - "mtu 9216"
+  connection: network_cli
+
+- name: "dellemc.os9: set access mode vlan"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface vlan {{ _vlan_id }}"
+      - "untagged {{ port_name }}"
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_access_port.yaml
@@ -5,15 +5,22 @@
       - "default interface {{ port_name }}"
   connection: network_cli
 
-- name: "dellemc.os9: enable switchport, rstp, and jumbo frames"
+- name: "dellemc.os9: enable switchport and jumbo frames"
   dellemc.os9.os9_config:
     lines:
       - "interface {{ port_name }}"
       - "switchport"
       - "no shutdown"
-      - "spanning-tree rstp edge-port"
       - "mtu 9216"
   connection: network_cli
+
+- name: "dellemc.os9: enable rstp"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface {{ port_name }}"
+      - "spanning-tree rstp edge-port"
+  connection: network_cli
+  when: stp_edge
 
 - name: "dellemc.os9: set access mode vlan"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -5,16 +5,23 @@
       - "default interface {{ port_name }}"
   connection: network_cli
 
-- name: "dellemc.os9: enable switchport, hybrid portmode, rstp and jumbo frames"
+- name: "dellemc.os9: enable switchport, hybrid portmode, and jumbo frames"
   dellemc.os9.os9_config:
     lines:
       - "interface {{ port_name }}"
       - "portmode hybrid"
       - "switchport"
-      - "spanning-tree rstp edge-port"
       - "mtu 9216"
       - "no shutdown"
   connection: network_cli
+
+- name: "dellemc.os9: enable rstp"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface {{ port_name }}"
+      - "spanning-tree rstp edge-port"
+  connection: network_cli
+  when: stp_edge
 
 - name: "dellemc.os9: set native vlan"
   dellemc.os9.os9_config:

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/conf_trunk_port.yaml
@@ -1,0 +1,34 @@
+---
+- name: "dellemc.os9: reset interface to default"
+  dellemc.os9.os9_config:
+    lines:
+      - "default interface {{ port_name }}"
+  connection: network_cli
+
+- name: "dellemc.os9: enable switchport, hybrid portmode, rstp and jumbo frames"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface {{ port_name }}"
+      - "portmode hybrid"
+      - "switchport"
+      - "spanning-tree rstp edge-port"
+      - "mtu 9216"
+      - "no shutdown"
+  connection: network_cli
+
+- name: "dellemc.os9: set native vlan"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface vlan {{ _vlan_id }}"
+      - "untagged {{ port_name }}"
+  connection: network_cli
+
+- name: "dellemc.os9: add trunk vlan(s)"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface vlan {{ t_vlan }}"
+      - "tagged {{ port_name }}"
+  loop: "{{ trunked_vlans }}"
+  loop_control:
+    loop_var: t_vlan
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/create_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/create_vlan.yaml
@@ -1,0 +1,8 @@
+---
+- name: "dellemcos9: create vlan"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface vlan {{ _vlan_id }}"
+      - "name {{ _vlan_name }}"
+      - "no shutdown"
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/defaults.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/defaults.yaml
@@ -1,0 +1,3 @@
+---
+_vlan_id: "{{ vlan_id | default(1, True)}}"
+_vlan_name: '{{ vlan_name if vlan_name else "default" if vlan_id|string == "1" else "vlan"+vlan_id|string }}'

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/delete_port.yaml
@@ -1,0 +1,6 @@
+---
+- name: "dellemc.os9: reset interface to default (no switchport and shutdown)"
+  dellemc.os9.os9_config:
+    lines:
+      - "default interface {{ port_name }}"
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/delete_trunk_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/delete_trunk_vlan.yaml
@@ -1,0 +1,7 @@
+---
+- name: "dellemc.os9: delete a vlan from trunk port"
+  dellemc.os9.os9_config:
+    lines:
+      - "interface vlan {{ _vlan_id }}"
+      - "no tagged {{ port_name }}"
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/delete_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/delete_vlan.yaml
@@ -1,0 +1,6 @@
+---
+- name: "dellemcos9: delete vlan"
+  dellemc.os9.os9_config:
+    lines:
+      - "no interface vlan {{ _vlan_id }}"
+  connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/list_vlans.yaml
+++ b/etc/ansible/roles/network-runner/providers/dellemc.os9.os9/list_vlans.yaml
@@ -1,0 +1,4 @@
+---
+- fail:
+    msg: List VLANs is not implimented for dellemc.os9.os9
+


### PR DESCRIPTION
this uses the ansible galaxy collection for os9: https://galaxy.ansible.com/dellemc/os9
specifically the dellemc.os9.os9_config  plugin.

I chose to enable jumbo frames and rstp when configuring trunk/access ports which
I can change if folks aren't happy about it.

Tested it on a Dell S4048-ON running Dell EMC Application Software Version 9.14(2.5)