### PR TITLE
import abstract base classes from second level module

### DIFF
--- a/network_runner/types/containers.py
+++ b/network_runner/types/containers.py
@@ -18,7 +18,7 @@
 #
 import json
 
-from collections import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence
 
 from six import iteritems
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
 
     setuptools.setup(
         name='network-runner',
-        version='0.3.5',
+        version='0.3.6',
         description='Abstracton and Python API for Ansible Networking',
         long_description=long_description,
         author='Ansible',


### PR DESCRIPTION
This is needed for py 3.10 compat.
https://bugs.python.org/issue37324