### PR TITLE
Avoid deleting openvswitch port

### DIFF
--- a/etc/ansible/roles/network-runner/providers/openvswitch/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/openvswitch/delete_port.yaml
@@ -3,5 +3,6 @@
   openvswitch_port:
     bridge: "{{ bridge_name }}"
     port: "{{ port_name }}"
-    state: absent
+    tag: []
+    state: present
   become: true


### PR DESCRIPTION
The delete_port() of openvswitch will delete the port instead of clearing the configuration.
Please refer to the relevant parameter description [here](https://github.com/ansible-collections/openvswitch.openvswitch/blob/main/docs/openvswitch.openvswitch.openvswitch_port_module.rst).

Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>