### PR TITLE
disable the network-runner-test-functional-eos job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,10 +1,5 @@
 ---
 - job:
-    name: network-runner-test-functional-eos
-    parent: ansible-network-eos-appliance
-    run: tests/run.yaml
-
-- job:
     name: network-runner-test-functional-junos
     parent: ansible-network-junos-appliance
     run: tests/run.yaml

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -2,11 +2,9 @@
 - project:
     check:
       jobs:
-        - network-runner-test-functional-eos
         - network-runner-test-functional-junos
         - network-runner-test-functional-nxos
     gate:
       jobs:
-        - network-runner-test-functional-eos
         - network-runner-test-functional-junos
         - network-runner-test-functional-nxos


### PR DESCRIPTION
We don't define the parent job anymore in ansible-zuul-jobs.
See: https://github.com/ansible/ansible-zuul-jobs/pull/1389
