### PR TITLE
Improve performance of the NOS driver

### DIFF
--- a/etc/ansible/roles/network-runner/providers/nos/add_trunk_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/add_trunk_vlan.yaml
@@ -5,4 +5,5 @@
       - "switchport trunk allowed vlan add {{ _vlan_id }}"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/nos/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/conf_access_port.yaml
@@ -6,6 +6,7 @@
       - "shutdown"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli
 
 - name: "nos: enable switchport in access mode"
@@ -16,6 +17,7 @@
       - "no shutdown"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli
 
 - name: "nos: enable rstp"
@@ -24,6 +26,7 @@
       - "no spanning-tree shutdown"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli
   when: stp_edge
 
@@ -33,4 +36,5 @@
       - "switchport access vlan {{ _vlan_id }}"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/nos/conf_access_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/conf_access_port.yaml
@@ -1,38 +1,13 @@
 ---
-- name: "nos: reset interface to default"
+- name: "nos: restore config and then configure access port"
   community.network.nos_config:
     lines:
       - "no switchport"
       - "shutdown"
-    parents:
-      - "interface {{ port_name }}"
-    match: none
-  connection: network_cli
-
-- name: "nos: enable switchport in access mode"
-  community.network.nos_config:
-    lines:
       - "switchport"
       - "switchport mode access"
       - "no shutdown"
-    parents:
-      - "interface {{ port_name }}"
-    match: none
-  connection: network_cli
-
-- name: "nos: enable rstp"
-  community.network.nos_config:
-    lines:
       - "no spanning-tree shutdown"
-    parents:
-      - "interface {{ port_name }}"
-    match: none
-  connection: network_cli
-  when: stp_edge
-
-- name: "nos: set access mode vlan"
-  community.network.nos_config:
-    lines:
       - "switchport access vlan {{ _vlan_id }}"
     parents:
       - "interface {{ port_name }}"

--- a/etc/ansible/roles/network-runner/providers/nos/conf_trunk_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/conf_trunk_port.yaml
@@ -1,48 +1,28 @@
 ---
-- name: "nos: reset interface to default"
+- name: "nos: reset interface to default and then configure it in trunk mode with native-vlan"
   community.network.nos_config:
     lines:
       - "no switchport"
       - "shutdown"
-    parents:
-      - "interface {{ port_name }}"
-  connection: network_cli
-
-- name: "nos: enable switchport in trunk mode and disable tagging of native-vlan"
-  community.network.nos_config:
-    lines:
       - "switchport"
       - "switchport mode trunk"
       - "no switchport trunk tag native-vlan"
       - "no shutdown"
-    parents:
-      - "interface {{ port_name }}"
-  connection: network_cli
-
-- name: "nos: enable rstp"
-  community.network.nos_config:
-    lines:
       - "no spanning-tree shutdown"
-    parents:
-      - "interface {{ port_name }}"
-  connection: network_cli
-  when: stp_edge
-
-- name: "nos: set native vlan"
-  community.network.nos_config:
-    lines:
       - "switchport trunk allowed vlan add {{ _vlan_id }}"
       - "switchport trunk native-vlan {{ _vlan_id }}"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli
 
-- name: "nos: add trunk vlan(s)"
+- name: "nos: add the remainder of trunk vlan(s)"
   community.network.nos_config:
     lines:
       - "switchport trunk allowed vlan add {{ t_vlan }}"
     parents:
       - "interface {{ port_name }}"
+    match: none
   loop: "{{ trunked_vlans }}"
   loop_control:
     loop_var: t_vlan

--- a/etc/ansible/roles/network-runner/providers/nos/create_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/create_vlan.yaml
@@ -5,4 +5,5 @@
       - "name {{ _vlan_name }}"
     parents:
       - "interface vlan {{ _vlan_id }}"
+    match: none
   connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/nos/delete_port.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/delete_port.yaml
@@ -6,4 +6,5 @@
       - "shutdown"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/nos/delete_trunk_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/delete_trunk_vlan.yaml
@@ -5,4 +5,5 @@
       - "switchport trunk allowed vlan remove {{ _vlan_id }}"
     parents:
       - "interface {{ port_name }}"
+    match: none
   connection: network_cli

--- a/etc/ansible/roles/network-runner/providers/nos/delete_vlan.yaml
+++ b/etc/ansible/roles/network-runner/providers/nos/delete_vlan.yaml
@@ -3,4 +3,5 @@
   community.network.nos_config:
     lines:
       - "no interface vlan {{ _vlan_id }}"
+    match: none
   connection: network_cli


### PR DESCRIPTION
Without these optimizations, it was taking around 9-10 minutes to configure a a switchport in access mode. The commits in this PR cuts this down by half. There are 2 major changes:

1. I noticed that the nos community plugin tries to get the host-name of the switch for every call `show running-config | include  host-name`. In our case, because the switches are stacked this returns the configuration from all of our 8 stacked switches which takes a while to generate. By setting match to none, it ignores comparing[1] the source config and running config.
2. I decided to batch all the commands together so we push all commands to the switch at once instead of multiple round trips. 

Not sure if this has a place in this repository as the driver without the optimizations maybe okay for people who don't have their switches stacked, but I wanted to submit this in case folks are interested.

[1] https://docs.ansible.com/ansible/latest/collections/community/network/nos_config_module.html#parameter-match
